### PR TITLE
#15 Allow the user to select with LLM to use in the matcher

### DIFF
--- a/R/match_instruments.R
+++ b/R/match_instruments.R
@@ -137,8 +137,6 @@ match_instruments <- function(instruments,
     #contents
     conten <- content(res)
 
-    print(bod)
-
     # for the clusters, we need to add 1 to the item_ids since R indexes from 1 (whereas python indexes from 0)
     for (i in seq_along(conten$clusters)) {
         for (j in seq_along(conten$clusters[[i]]$item_ids)) {

--- a/R/match_instruments.R
+++ b/R/match_instruments.R
@@ -41,14 +41,12 @@
 #'
 #' @param ... Optional named arguments:
 #' \describe{
-#'   \item{model}{The HuggingFace model to be used by the matcher.
-#'     Currently recommended models to use with Harmony are:
+#'   \code{model} The HuggingFace model to be used by the matcher. Currently recommended models to use with Harmony are:
 #'     \itemize{
 #'       \item \code{sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2}
 #'       \item \code{sentence-transformers/paraphrase-multilingual-mpnet-base-v2}
 #'       \item \code{harmonydata/mental_health_harmonisation_1}
 #'     }
-#'   }
 #' }
 #'
 #' @return A list containing the matched instruments retrieved from the Harmony Data API. The returned object includes attributes such as the similarity matrix, identified clusters, associated cluster topics, and other relevant metadata.
@@ -70,6 +68,15 @@
 #' matched_instruments <- match_instruments(
 #'   instruments,
 #'   topics = list("anxiety", "depression")
+#' )
+#'
+#' # with optional arguments
+#' matched_instruments <- match_instruments(
+#'   instruments,
+#'   topics = list("anxiety", "depression"),
+#'   is_negate = TRUE,
+#'   clustering_algorithm = "affinity_propagation",
+#'   model = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 #' )
 #' }
 #'

--- a/man/match_instruments.Rd
+++ b/man/match_instruments.Rd
@@ -8,7 +8,8 @@ match_instruments(
   instruments,
   topics = list(),
   is_negate = TRUE,
-  clustering_algorithm = "affinity_propagation"
+  clustering_algorithm = "affinity_propagation",
+  ...
 )
 }
 \arguments{
@@ -27,6 +28,18 @@ When \code{is_negate = FALSE}, negation is skipped and most similarity values re
 The Harmony API defaults to \code{is_negate = TRUE}, as some users prefer detecting antonymy through negative similarity values, while others may prefer only positive scores.'}
 
 \item{clustering_algorithm}{A string value to select the clustering algorithm to use. Must be one of: "affinity_propagation", "kmeans", "deterministic", "hdbscan". Default is "affinity_propagation".}
+
+\item{...}{Optional named arguments:
+\describe{
+  \item{model}{The HuggingFace model to be used by the matcher.
+    Currently recommended models to use with Harmony are:
+    \itemize{
+      \item \code{sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2}
+      \item \code{sentence-transformers/paraphrase-multilingual-mpnet-base-v2}
+      \item \code{harmonydata/mental_health_harmonisation_1}
+    }
+  }
+}}
 }
 \value{
 A list containing the matched instruments retrieved from the Harmony Data API. The returned object includes attributes such as the similarity matrix, identified clusters, associated cluster topics, and other relevant metadata.

--- a/man/match_instruments.Rd
+++ b/man/match_instruments.Rd
@@ -31,14 +31,12 @@ The Harmony API defaults to \code{is_negate = TRUE}, as some users prefer detect
 
 \item{...}{Optional named arguments:
 \describe{
-  \item{model}{The HuggingFace model to be used by the matcher.
-    Currently recommended models to use with Harmony are:
+  \code{model} The HuggingFace model to be used by the matcher. Currently recommended models to use with Harmony are:
     \itemize{
       \item \code{sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2}
       \item \code{sentence-transformers/paraphrase-multilingual-mpnet-base-v2}
       \item \code{harmonydata/mental_health_harmonisation_1}
     }
-  }
 }}
 }
 \value{
@@ -65,6 +63,15 @@ instruments <- list(instrument_A, instrument_B)
 matched_instruments <- match_instruments(
   instruments,
   topics = list("anxiety", "depression")
+)
+
+# with optional arguments
+matched_instruments <- match_instruments(
+  instruments,
+  topics = list("anxiety", "depression"),
+  is_negate = TRUE,
+  clustering_algorithm = "affinity_propagation",
+  model = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 )
 }
 


### PR DESCRIPTION
## Description

This change addresses issue #15. I have added an optional argument `model` using R's keyword arguments feature `...`, so that it will default to whichever LLM the harmonyapi defaults to. I have updated the documentation for the `match_instruments` function to reflect this.

#### Fixes #15 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

#### Test Configuration

* Library version: Version 0.2.1 (2025-03-03)
* OS: Windows 11
* Toolchain: R version 4.4.3 (2025-02-28 ucrt)

## Checklist

- [x] My PR is for one issue, rather than for multiple unrelated fixes.
- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I add third party dependencies only when necessary.
- [x] If I introduced a new feature, I documented it (e.g. making a script example in the [script examples repository](https://github.com/harmonydata/harmony_examples) so that people will know how to use it.

Optionally: feel free to paste your Discord username in this format: `discordapp.com/users/yourID` in your pull request description, then we can know to tag you in the Harmony Discord server when we announce the PR.
